### PR TITLE
Fixing a server issue where the server and client messages were not being recycled and another one where the clients weren't successfully disconnecting from the server

### DIFF
--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -134,6 +134,7 @@ class EnetClientConnection : NetworkClientConnection
         message.Offset = 0;
         message.Count = netEvent.Packet.Length;
         HandleMessageReceived(message, SendMode.Reliable);
+        message.Dispose();
     }
 
     public void PerformUpdate()

--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -25,6 +25,7 @@ class EnetClientConnection : NetworkClientConnection
     private Host client;
     private Peer peer;
     private Task clientTask;
+    private bool disposedValue = false;
 
     //Whether we're connected
     public override ConnectionState ConnectionState
@@ -83,11 +84,27 @@ class EnetClientConnection : NetworkClientConnection
     //Called when the server wants to disconnect the client
     public override bool Disconnect()
     {
-        peer.Disconnect(0);
+        peer.DisconnectNow(0);
         client.Dispose();
         return true;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposedValue)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            Disconnect();
+        }
+
+        disposedValue = true;
+    }
 
     //We should call HandleMessageReceived(MessageBuffer message, SendMode sendMode) when we get a new message from the client
     //And HandleDisconnection(...) if the client disconnects

--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -68,6 +68,7 @@ class EnetClientConnection : NetworkClientConnection
         Array.Copy(message.Buffer, message.Offset,data,0, message.Count);
         bool r = SendReliable(data, 1, peer);
         client.Flush();
+        message.Dispose();
         return r;
     }
 
@@ -78,6 +79,7 @@ class EnetClientConnection : NetworkClientConnection
         Array.Copy(message.Buffer, message.Offset, data, 0, message.Count);
         bool r = SendUnreliable(data, 2, peer);
         client.Flush();
+        message.Dispose();
         return r;
     }
 

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -99,5 +99,6 @@ public class EnetServerConnection : NetworkServerConnection {
         message.Offset = 0;
         message.Count = netEvent.Packet.Length;
         HandleMessageReceived(message, SendMode.Reliable);
+        message.Dispose();
     }
 }

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -48,6 +48,7 @@ public class EnetServerConnection : NetworkServerConnection {
     {
         byte[] data = new byte[message.Count];
         Array.Copy(message.Buffer, message.Offset, data, 0, message.Count);
+        message.Dispose();
         return SendReliable(data, 1, peer);
     }
 
@@ -55,6 +56,7 @@ public class EnetServerConnection : NetworkServerConnection {
     {
         byte[] data = new byte[message.Count];
         Array.Copy(message.Buffer, message.Offset, data, 0, message.Count);
+        message.Dispose();
         return SendUnreliable(data, 2, peer);
     }
 


### PR DESCRIPTION
1. Adding calls to message.Dispose() to both SendMessageReliable() and SendMessageUnreliable() in the EnetServerConnection and EnetClientConnection classes so that messages can be recycled back to the pool.

2. Also changing the client code to use DisconnectNow() instead of Disconnect() plus adding an override to the Dispose() method in EnetClientConnection similar to how it's done in the BichannelClientConnection class.  Both of these changes are needed for the EnetClientConnection.Disconnect() to be called.
Documentation for the three ENet Disconnect methods is here: http://enet.bespin.org/group__peer.html#ga0e807704b6ecace5004c2cdcfbf813c2
Calling Disconnect() or DisconnectLater() doesn't seem to work nicely with the server for some reason; I can only get DisconnectNow() to work properly.