### PR TITLE
More fixes and improvements

### DIFF
--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -134,6 +134,7 @@ class EnetClientConnection : NetworkClientConnection
         message.Offset = 0;
         message.Count = netEvent.Packet.Length;
         HandleMessageReceived(message, SendMode.Reliable);
+        message.Dispose();
     }
 
     public void PerformUpdate()

--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -18,6 +18,8 @@ class EnetClientConnection : NetworkClientConnection
         Library.Initialize();
         this.ip = ip;
         this.port = port;
+
+        remoteEndPoints = new[] {new IPEndPoint(IPAddress.Parse(ip), port)};
     }
 
     private string ip;
@@ -26,6 +28,7 @@ class EnetClientConnection : NetworkClientConnection
     private Peer peer;
     private Task clientTask;
     private bool disposedValue = false;
+    private readonly IPEndPoint[] remoteEndPoints;
 
     //Whether we're connected
     public override ConnectionState ConnectionState
@@ -39,7 +42,7 @@ class EnetClientConnection : NetworkClientConnection
     {
         get
         {
-            return new List<IPEndPoint>();
+            return remoteEndPoints;
         }
     }
 

--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -25,6 +25,7 @@ class EnetClientConnection : NetworkClientConnection
     private Host client;
     private Peer peer;
     private Task clientTask;
+    private bool disposedValue = false;
 
     //Whether we're connected
     public override ConnectionState ConnectionState
@@ -83,11 +84,27 @@ class EnetClientConnection : NetworkClientConnection
     //Called when the server wants to disconnect the client
     public override bool Disconnect()
     {
-        peer.Disconnect(0);
+        peer.DisconnectNow(0);
         client.Dispose();
         return true;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposedValue)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            Disconnect();
+        }
+
+        disposedValue = true;
+    }
 
     //We should call HandleMessageReceived(MessageBuffer message, SendMode sendMode) when we get a new message from the client
     //And HandleDisconnection(...) if the client disconnects

--- a/EnetClientConnection.cs
+++ b/EnetClientConnection.cs
@@ -68,6 +68,7 @@ class EnetClientConnection : NetworkClientConnection
         Array.Copy(message.Buffer, message.Offset,data,0, message.Count);
         bool r = SendReliable(data, 1, peer);
         client.Flush();
+        message.Dispose();
         return r;
     }
 
@@ -78,6 +79,7 @@ class EnetClientConnection : NetworkClientConnection
         Array.Copy(message.Buffer, message.Offset, data, 0, message.Count);
         bool r = SendUnreliable(data, 2, peer);
         client.Flush();
+        message.Dispose();
         return r;
     }
 

--- a/EnetListenerPlugin.cs
+++ b/EnetListenerPlugin.cs
@@ -51,12 +51,11 @@ public class EnetListenerPlugin : NetworkListener
                     break;
 
                 case EventType.Disconnect:
-                    Console.WriteLine("Client: " + netEvent.Peer.IP + netEvent.Peer.Port + " disconnected.");
-                    connections[netEvent.Peer].OnDisconnect();
-                    connections.Remove(netEvent.Peer);
+                    HandleDisconnection(netEvent);
                     break;
 
                 case EventType.Timeout:
+                    HandleDisconnection(netEvent);
                     break;
 
                 case EventType.Receive:
@@ -77,5 +76,12 @@ public class EnetListenerPlugin : NetworkListener
 
         }
         server.Flush();
+    }
+
+    void HandleDisconnection(Event netEvent)
+    {
+        Console.WriteLine("Client: " + netEvent.Peer.IP + netEvent.Peer.Port + " disconnected.");
+        connections[netEvent.Peer].OnDisconnect();
+        connections.Remove(netEvent.Peer);
     }
 }

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -98,7 +98,7 @@ public class EnetServerConnection : NetworkServerConnection {
         netEvent.Packet.CopyTo(message.Buffer);
         message.Offset = 0;
         message.Count = netEvent.Packet.Length;
-        HandleMessageReceived(message, SendMode.Reliable);
+        HandleMessageReceived(message, mode);
         message.Dispose();
     }
 }

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -13,19 +13,21 @@ public class EnetServerConnection : NetworkServerConnection {
         get { return connectionState; }
     }
     private ConnectionState connectionState;
+    private readonly IPEndPoint[] remoteEndPoints;
 
     //A list of endpoints we're connected to on the server
     public override IEnumerable<IPEndPoint> RemoteEndPoints
     {
         get
         {
-            return new List<IPEndPoint>();
+            return remoteEndPoints;
         }
     }
 
     public EnetServerConnection(Peer peer)
     {
         this.peer = peer;
+        remoteEndPoints = new[] {new IPEndPoint(IPAddress.Parse(peer.IP), peer.Port)};
     }
 
     private Peer peer;

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -99,5 +99,6 @@ public class EnetServerConnection : NetworkServerConnection {
         message.Offset = 0;
         message.Count = netEvent.Packet.Length;
         HandleMessageReceived(message, SendMode.Reliable);
+        message.Dispose();
     }
 }

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -28,8 +28,6 @@ public class EnetServerConnection : NetworkServerConnection {
         this.peer = peer;
     }
 
-    private string ip;
-    private int port;
     private Peer peer;
 
 

--- a/EnetServerConnection.cs
+++ b/EnetServerConnection.cs
@@ -48,6 +48,7 @@ public class EnetServerConnection : NetworkServerConnection {
     {
         byte[] data = new byte[message.Count];
         Array.Copy(message.Buffer, message.Offset, data, 0, message.Count);
+        message.Dispose();
         return SendReliable(data, 1, peer);
     }
 
@@ -55,6 +56,7 @@ public class EnetServerConnection : NetworkServerConnection {
     {
         byte[] data = new byte[message.Count];
         Array.Copy(message.Buffer, message.Offset, data, 0, message.Count);
+        message.Dispose();
         return SendUnreliable(data, 2, peer);
     }
 


### PR DESCRIPTION
1. Handling the client timeout event on the server so that when a clients is timed out, the server will correctly handle the disconnection.
2. Replacing the hardcoded SendMode in EnetServerConnection.HandleEnetMessageReceived to the appropriate one.
3. Setting the correct remote end point in EnetServerConnection which is used for logging purposes.